### PR TITLE
Switch to CanCanCan

### DIFF
--- a/protector-cancan.gemspec
+++ b/protector-cancan.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "protector", ">= 0.5.3"
-  spec.add_dependency "cancan"
+  spec.add_dependency "cancancan"
   spec.add_dependency "activesupport"
 end


### PR DESCRIPTION
Move dependency to the community maintained version of CanCan (cancancan), as the original was abandoned.

This is a reopen of #8, using the correct source branch.  
