### PR TITLE
Use cancan's scope restrictions when loading collections

### DIFF
--- a/lib/protector/cancan/resource.rb
+++ b/lib/protector/cancan/resource.rb
@@ -18,21 +18,17 @@ module Protector
       end
 
       def load_collection_with_protector
-        resource = resource_base
+        resource = load_collection_without_protector
 
         if resource_protectable? resource
-          resource
+          resource.restrict!(current_ability.protector_subject)
         else
-          load_collection_without_protector
+          resource
         end
       end
 
       def load_collection_with_protector?
-        if resource_protectable? resource_base
-          true
-        else
-          load_collection_without_protector?
-        end
+        load_collection_without_protector? || resource_protectable?(resource_base)
       end
 
       private


### PR DESCRIPTION
The current way we were loading collections with CanCan wasn't applying any of their custom scopes. Ex:  I have an ability file with this in it: 

``` ruby
can [:read, :update, :search], Client, { practice_id: practice.id }
```

which restricts actions to the owner of a particular record.  When I hit the index of the ClientsController, I would get all the clients (without the practice id restriction).  This fixes it so I can again use CanCan restrictions.  

I also cleaned up the `load_collection_with_proctor?` method.  It's simpler now and has the same functionality.  
